### PR TITLE
Search perf

### DIFF
--- a/app/react/actions/SearchAPI.js
+++ b/app/react/actions/SearchAPI.js
@@ -5,7 +5,7 @@ const superagent = require('superagent');
 let jsonp = require('superagent-jsonp');
 
 const wiki_api = "https://en.wikipedia.org/w/api.php?action=";
-const generator = `${wiki_api}query&formatversion=2&format=json&generator=prefixsearch&gpslimit=10&prop=pageimages|pageterms|info&inprop=url&piprop=thumbnail&pithumbsize=50&pilimit=10&redirects=&wbptterms=description&gpssearch=`
+const generator = `${wiki_api}query&formatversion=2&format=json&generator=prefixsearch&gpslimit=99&prop=pageimages|pageterms|info&inprop=url&piprop=thumbnail&pithumbsize=50&pilimit=99&redirects=&wbptterms=description&gpssearch=`
 const redirects = "&redirects="
 
 let pendingSearch;

--- a/app/react/actions/SearchAPI.js
+++ b/app/react/actions/SearchAPI.js
@@ -5,8 +5,6 @@ const superagent = require('superagent');
 let jsonp = require('superagent-jsonp');
 
 const wiki_api = "https://en.wikipedia.org/w/api.php?action=";
-const generator = `${wiki_api}query&formatversion=2&format=json&generator=prefixsearch&gpslimit=99&prop=pageimages|pageterms|info&piprop=thumbnail&pithumbsize=50&pilimit=99&redirects=&wbptterms=description&gpssearch=`
-const redirects = "&redirects="
 
 const SEARCH_MAX_RESULTS = 50
 const SEARCH_THUMBNAIL_WIDTH = 75

--- a/app/react/actions/SearchAPI.js
+++ b/app/react/actions/SearchAPI.js
@@ -5,21 +5,44 @@ const superagent = require('superagent');
 let jsonp = require('superagent-jsonp');
 
 const wiki_api = "https://en.wikipedia.org/w/api.php?action=";
-const generator = `${wiki_api}query&formatversion=2&format=json&generator=prefixsearch&gpslimit=99&prop=pageimages|pageterms|info&inprop=url&piprop=thumbnail&pithumbsize=50&pilimit=99&redirects=&wbptterms=description&gpssearch=`
+const generator = `${wiki_api}query&formatversion=2&format=json&generator=prefixsearch&gpslimit=99&prop=pageimages|pageterms|info&piprop=thumbnail&pithumbsize=50&pilimit=99&redirects=&wbptterms=description&gpssearch=`
 const redirects = "&redirects="
+
+const SEARCH_MAX_RESULTS = 50
+const SEARCH_THUMBNAIL_WIDTH = 75
 
 let pendingSearch;
 
 export function search(query, callback) {
+
+   const params = {
+     formatversion: 2,
+     format: 'json',
+     action: 'query',
+     generator: 'prefixsearch',
+     gpssearch: query,
+     gpsnamespace: 0,
+     gpslimit: SEARCH_MAX_RESULTS,
+     prop: 'pageterms|pageimages|info',
+     inprop: 'url',
+     piprop: 'thumbnail',
+     wbptterms: 'description',
+     pithumbsize : SEARCH_THUMBNAIL_WIDTH,
+     pilimit: SEARCH_MAX_RESULTS,
+     list: 'prefixsearch',
+     pssearch: query,
+     pslimit: SEARCH_MAX_RESULTS
+  }
+
   if (pendingSearch) {
     pendingSearch.cancel();
   }
 
-  var encoded_query = encodeURIComponent(query);
-
-  pendingSearch = superagent(generator + encoded_query)
+  pendingSearch = superagent(wiki_api)
   .use(jsonp)
+  .query(params)
   .end((err, res) => {
+    pendingSearch = null
     if(err) {
       console.log('error fetching search', err);
     } else {

--- a/app/react/components/SearchForm.js
+++ b/app/react/components/SearchForm.js
@@ -3,13 +3,17 @@ import { search } from '../actions/SearchAPI';
 import Icon from './Icon';
 
 export default class SearchForm extends React.Component {
+  constructor() {
+    super()
+    this._debouncedSearch = _.debounce(this._debouncedSearch, 300)
+  }
+
   render() {
     return (
       <form onSubmit={e => e.preventDefault()}>
         <div className='relative'>
           <input onKeyUp={this._handleKeyUp.bind(this)}
-               onKeyDown={this._handleKeyDown.bind(this)}
-               id='Search' 
+               id='Search'
                type='text'
                autoComplete='off'
                placeholder='Search Wikipedia'
@@ -22,19 +26,16 @@ export default class SearchForm extends React.Component {
   }
 
   _handleKeyUp(e) {
+    e.persist()
+    this._debouncedSearch(e.target.value)
+  }
+
+  _debouncedSearch(query) {
     const {dispatch, index} = this.props;
-    const query = e.target.value;
     dispatch(updateQuery(index, query))
-    this.queryTimeout = setTimeout(()=>{
-      dispatch(isSearching(true))
-      search(query, this._handleResults.bind(this));
-    }, 700)
+    dispatch(isSearching(true))
+    search(query, this._handleResults.bind(this));
   }
-
-  _handleKeyDown(e) {
-    clearTimeout(this.queryTimeout)
-  }
-
   _handleResults(results) {
     this.props.dispatch(addSearch(results, this.props.index))
     this.props.dispatch(isSearching(false))

--- a/app/react/components/SearchResult.js
+++ b/app/react/components/SearchResult.js
@@ -4,7 +4,7 @@ import Icon from './Icon';
 import es6BindAll from "es6bindall";
 
 import {
-  addArticle, 
+  addArticle,
   updateQuery,
   addArticleImages,
   updateCurrentEditingArticle
@@ -20,7 +20,7 @@ class SearchResult extends React.Component {
 
   render() {
     const {title, thumbnail, terms, fullurl} = this.props.article;
-    const thumb = (thumbnail !== undefined ? <div><img src={thumbnail.source}/></div> : null)
+    const thumb = (thumbnail !== undefined ? <div style={{width: 50, height: 50, backgroundImage: `url(${thumbnail.source})`, backgroundSize: 'cover', backgroundPosition: 'center center'}}></div> : null)
     const description = (terms !== undefined && terms.description !== undefined ? <p className='search-result__description'>{terms.description}</p> : null)
     return (
       <div className='search-result border mb2 bg-white'>
@@ -41,7 +41,7 @@ class SearchResult extends React.Component {
   handleAddArticle() {
     const {dispatch, article, Playlist} = this.props;
     const index = Playlist.editingArticle;
-    
+
     let articleData = new Promise((resolve, reject)=>{
       fetchArticleSummary(article.title).done((data)=> {
 
@@ -59,7 +59,7 @@ class SearchResult extends React.Component {
     articleData.then(()=>{
       dispatch(addArticle(index, article));
       fetchArticleImages(article.title, this.addArticleImages.bind(this));
-    }).catch((reason)=> {console.log('Reject promise', reason)});    
+    }).catch((reason)=> {console.log('Reject promise', reason)});
   }
 
   addArticleImages(images) {


### PR DESCRIPTION
@hudakdidit Feel free to ignore/reject this (especially if you had already started on some of these ideas we had talked about), but this seems to improve search performance and consistency a bit.

- Images have a fixed size to prevent the bouncing around.
- Use lodash's debounce to ensure that the search api isn't called too frequently
- Use superagent's `cancel` to cancel pending requests to avoid issues where the responses happen in a different order than they were triggered. 
